### PR TITLE
Support <<display>> macro

### DIFF
--- a/lib/twparser.py
+++ b/lib/twparser.py
@@ -155,6 +155,8 @@ class Passage:
 			macro = EndMacro(token)
 		elif kind == 'music':
 			macro = MusicMacro(token)
+		elif kind == 'display':
+			macro = DisplayMacro(token)
 		else:
 			macro = InvalidMacro(token, 'unknown macro: ' + kind)
 
@@ -320,6 +322,17 @@ class SetMacro(AbstractMacro):
 
 class PauseMacro(AbstractMacro):
 	"""Class for the 'pause' macro"""
+
+
+class DisplayMacro(AbstractMacro):
+	"""Class for the 'display' macro"""
+
+	def _parse(self, token):
+		kind, params = token[1]
+		self.target = params.replace('"', '').strip()
+
+	def __repr__(self):
+		return "<cmd display: {0}>".format(self.target)
 
 
 class IfMacro(AbstractMacro):

--- a/twee2sam.py
+++ b/twee2sam.py
@@ -229,6 +229,13 @@ def main (argv):
 					if not cmd.path in music_list:
 						music_list.append(cmd.path)
 					script.write('{0}m\n'.format(music_list.index(cmd.path)))
+				elif cmd.kind == 'display':
+					try:
+						target = twp.passages[cmd.target]
+					except KeyError:
+						print >> sys.stderr, "Display macro target passage {0} not found!".format(cmd.target)
+						return
+					process_command_list(target.commands)
 
 		process_command_list(passage.commands)
 


### PR DESCRIPTION
The `<<display>>` macro allows the contents of another passage (including all of its links, macros, text, etc.) to be transcluded inside another passage.

In Twine, this happens at runtime; in twee2sam, passages are recursively processed to statically build their contents at buildtime instead.