### PR TITLE
Added call and return functions to jump to and return from named text pa...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -75,6 +75,23 @@ Examples:
 
 Note: &lt;&lt;else&gt;&gt; is not implemented yet.
 
+&lt;&lt;call *passage* &gt;&gt;
+---------
+
+Calls a passage of text - this is effectively how twee2sam converts the Twine passages into a link story, however it can also be used to call out to specific subroutines.
+
+Examples:
+
+&lt;&lt;call inventory_passage &gt;&gt;
+
+A *call* is most often used to jump to another text passage, once you have finished with the 'subroutine' passage, you can return back to the original position with the *return* command:
+
+Example:
+
+&lt;&lt;return&gt;&gt;
+
+The two above commands allow you to have 'subroutines' unconnected from your main Twine story which can be called from anywhere without using the traditional [[link]] syntax and then return back to the previous position - this would normally require the subroutine to know which passage to return back to, which does not work easily with subroutines that may be called from many different locations (high score screens, inventory/player status, a pause menu etc).
+
 &lt;&lt;music *"filename.epsgmod"*&gt;&gt;
 ---------
 

--- a/lib/twparser.py
+++ b/lib/twparser.py
@@ -149,6 +149,10 @@ class Passage:
 			macro = PauseMacro(token)
 		elif kind == 'if':
 			macro = self._parse_if(token, tokens)
+                elif kind == 'call':
+                        macro = CallMacro(token)
+                elif kind == 'return':
+                        macro = ReturnMacro(token)
 		elif kind == 'endif':
 			if self._block_stack and self._block_stack[-1].kind == 'if':
 				self._block_stack.pop()
@@ -175,9 +179,6 @@ class Passage:
 	def _warning(self, msg):
 		print 'Warning on {0}: {1}'.format(self.title, msg)
 
-
-
-
 class AbstractCmd:
 	"""Base class for the different kinds of commands"""
 
@@ -188,7 +189,6 @@ class AbstractCmd:
 
 	def __repr__(self):
 		return '<cmd {0}>'.format(self.kind)
-
 
 class TextCmd(AbstractCmd):
 	"""Class for text commands"""
@@ -254,9 +254,6 @@ class ListCmd(AbstractCmd):
 
 	def _parse(self, token):
 		self.ordered = token[0] != 'ul'
-
-
-
 
 class AbstractMacro(AbstractCmd):
 	"""Class for macros """
@@ -360,8 +357,6 @@ class SetMacro(AbstractMacro):
 		self.error = 'invalid "set" expression: ' + params
 		return
 		
-		
-
 class PauseMacro(AbstractMacro):
 	"""Class for the 'pause' macro"""
 
@@ -372,6 +367,30 @@ class PrintMacro(AbstractMacro):
 		kind, params = token[1]
 		self.expr = self._parse_print(params.lstrip())
 		self.target = self.expr
+
+class CallMacro(AbstractMacro):
+        """Class for a jump/call subroutine macro"""
+
+        RE_CALL = re.compile(r'\s*([A-Za-z0-9_]+)\s*$')
+
+        def _parse(self, token):
+		
+		kind, params = token[1]
+		
+		match = CallMacro.RE_CALL.match(params.lstrip().rstrip())
+		if match:
+			print("CallMacro: Call subroutine %s %s" % (kind, params))
+			self.target = match.group(1)
+			self.expr = self.target
+			return
+
+class ReturnMacro(AbstractMacro):
+        """Class for a return-from-subroutine macro"""
+
+        def _parse(self, token):
+        	print("ReturnMacro: Return from subroutine")
+		self.expr = True
+		return
 
 class IfMacro(AbstractMacro):
 	"""Class for the 'if' macro"""

--- a/twee2sam.py
+++ b/twee2sam.py
@@ -110,11 +110,9 @@ def main (argv):
 	for passage in twp.passages.values():
 		process_passage_index(passage)
 
-
 	#
 	# Generate the file list
 	#
-
 	passage_order = [psg for psg, idx in sorted(passage_indexes.items(), key=itemgetter(1))]
 
 
@@ -233,7 +231,6 @@ def main (argv):
 			op, val = expr
 			if (op is '') and (val not in [True, False]) and (val[0] != '$'):
 				intval = int(val)
-				print("Setting literal: %s" % val)
 				script.write(str(intval))
 			else:
 				if val is True:
@@ -245,6 +242,16 @@ def main (argv):
 
 				if op == 'not':
 					script.write(' 0=')
+
+                def out_call(cmd):
+                	call_target = None
+                	for k in passage_indexes.keys():
+                		if cmd.target == k:
+                			call_target = passage_indexes[k]
+                	if call_target:
+                		script.write(str(call_target))
+                		script.write('c')
+                		script.write('\n')
 
 		# Outputs all the text
 
@@ -263,8 +270,8 @@ def main (argv):
 					if text:
 						out_string(text)
 						check_print.pending = True
-                                elif cmd.kind == 'print':
-                                	out_print(cmd)                                	
+				elif cmd.kind == 'print':
+					out_print(cmd)                                	
 				elif cmd.kind == 'image':
 					check_print()
 					if not cmd.path in image_list:
@@ -284,6 +291,10 @@ def main (argv):
 					out_set(cmd)
 				elif cmd.kind == 'if':
 					out_if(cmd)
+				elif cmd.kind == 'call':
+					out_call(cmd)
+				elif cmd.kind == 'return':
+					script.write('$\n')
 				elif cmd.kind == 'music':
 					if not cmd.path in music_list:
 						music_list.append(cmd.path)


### PR DESCRIPTION
Now supports call and return commands to call out to subroutine passages from your Twine adventure and return back to the original parent once completed. It means that your subroutine doesn't need to be linked in via the normal [[name|link]] syntax beforehand and can be called (and returned!) from anywhere you want. Useful for command screens you may want to call from many places - current player status, inventory, high scores etc.